### PR TITLE
Ignore a global "module" variable

### DIFF
--- a/lib/rewire.loader.js
+++ b/lib/rewire.loader.js
@@ -16,7 +16,7 @@ function rewireLoader(src) {
             // Now all global variables are declared with a var statement so they can be changed via __set__()
             // without influencing global objects.
             'var global = window; ' + // window is our new global object
-            'eval(require("' + pathToGetImportGlobalsSrc + '")()); ' +
+            'eval(require("' + pathToGetImportGlobalsSrc + '")(["module"])); ' +
 
             // The module src is wrapped inside a self-executing function.
             // This is necessary to separate the module src from the preceding eval(importGlobalsSrc),


### PR DESCRIPTION
In case global scope has a variable "module" rewire-webpack will include
this variable into the rewired module using "var module = ...". The
function in getImportGlobalsSrc.js is responsible for copying the
globals into such "var ... = ..." definitions.

Webpack however starts each module with the following function wrapper:
"function(module, exports, **webpack_require**) {...}"

Having a "var module = ..." statement within this function will shadow
the "module" parameter from the function definition.

In consequence the module cannot export anything anymore as it exports
to a local variable.

This can be fixed by instructing getImportGlobalsSrc() to ignore the
module variable via "getImportGlobalsSrc(["module"])".
