### PR TITLE
Fixed compatibility with latest Webpack

### DIFF
--- a/lib/RewiredDependency.js
+++ b/lib/RewiredDependency.js
@@ -12,6 +12,7 @@ function RewiredDependency(request, range) {
 
 RewiredDependency.prototype = Object.create(Dependency.prototype);
 RewiredDependency.prototype.type = "rewire";
+RewiredDependency.prototype.constructor = RewiredDependency;
 RewiredDependency.prototype.isEqualResource = function (other) {
     return other instanceof RewiredDependency?
             this.request === other.request:


### PR DESCRIPTION
As of webpack/webpack@5acfacfdd667f1a0b340f034cae6ce6c198e5c06 `.Class`
webpack is using `Dependency::constructor` over `Dependency::Class`. I
decided to keep the `.Class` for backwards compatibility.

Fixes jhnns/rewire-webpack#16