### PR TITLE
Add valid SPDX license identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "main": "lib/RewirePlugin.js",
   "homepage": "https://github.com/jhnns/rewire-webpack",
   "repository": "git://github.com/jhnns/rewire-webpack.git",
+  "license": "Unlicense",
   "dependencies": {
     "enhanced-resolve": "^0.9.1",
     "webpack": "^1.12.6"


### PR DESCRIPTION
Adds the "Unlicense" license identifier from https://spdx.org/licenses/. 

See [here](https://github.com/npm/npm/issues/8918) for some interesting background minutes. This should help users which use tools to whitelist packages based on the license identifier in `package.json`, where `rewire-webpack` is currently being treated as proprietary software since the license cannot be automatically determined.
